### PR TITLE
hotfix Role validation message added, Organization and Testimonial de…

### DIFF
--- a/src/main/java/com/alkemy/ong/model/Organization.java
+++ b/src/main/java/com/alkemy/ong/model/Organization.java
@@ -2,12 +2,7 @@ package com.alkemy.ong.model;
 
 import java.time.LocalDate;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 
 import lombok.*;
@@ -55,7 +50,7 @@ public class Organization {
 	private LocalDate updated;
 
 	@Column(columnDefinition = "boolean default false")
-	private static final boolean deleted = Boolean.FALSE;
+	private final boolean deleted = Boolean.FALSE;
 
 }
 

--- a/src/main/java/com/alkemy/ong/model/Role.java
+++ b/src/main/java/com/alkemy/ong/model/Role.java
@@ -24,7 +24,7 @@ public class Role {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotBlank(message = "Name must be not empty")
+    @NotBlank(message = "{error.empty_field}")
     @Column(nullable = false)
     private String name;
 

--- a/src/main/java/com/alkemy/ong/model/Testimonial.java
+++ b/src/main/java/com/alkemy/ong/model/Testimonial.java
@@ -33,7 +33,7 @@ public class Testimonial {
     private String content;
 
     @Column(columnDefinition = "boolean default false")
-    private static final boolean deleted = Boolean.FALSE;
+    private final boolean deleted = Boolean.FALSE;
 
     @Column(updatable = false)
     @CreationTimestamp


### PR DESCRIPTION
Role validation message using messages.properties
Organization and Testimonial entities deleted field updated 

- Fixed field not persisted in the database
- Immutable, can't create a deleted object, only when object is deleted by delete endpoint (sql)
